### PR TITLE
Create scrollbars.css

### DIFF
--- a/src/Ui/media/scrollbars.css
+++ b/src/Ui/media/scrollbars.css
@@ -1,0 +1,19 @@
+@media (pointer:fine) {
+    ::-webkit-scrollbar {
+        width: 10px
+    }
+
+    ::-webkit-scrollbar-track {
+        background: 0 0;
+        border-radius: 5px
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background: rgba(180,180,180,.5);
+        border-radius: 5px
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+        background: #af3bff
+    }
+}


### PR DESCRIPTION
This is themed after ZeroNet's fixbutton. Hover over it to see it turn the same shade purple as the fixbutton hovered. This only works in browsers using ```::-webkit``` selectors and a fine pointer such as a mouse*.

*There's a jittering/flickering bug on touch devices like Android, so this CSS excludes them.

Link to it:  ```<link rel="stylesheet" href="/uimedia/scrollbars.css" />```

Would be nice to see this used on more sites such as ZeroHello and ZeroTalk.